### PR TITLE
Replace forbidden chars in local version label

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   tests:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: ['2.7', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9']

--- a/setuptools_git_versioning.py
+++ b/setuptools_git_versioning.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 
 from setuptools.dist import Distribution
@@ -179,4 +180,9 @@ def version_from_git(template=DEFAULT_TEMPLATE,
     else:
         t = template
 
-    return t.format(sha=full_sha[:8], tag=tag, ccount=ccount, branch=branch, full_sha=full_sha)
+    version = t.format(sha=full_sha[:8], tag=tag, ccount=ccount, branch=branch, full_sha=full_sha)
+
+    # Ensure local version label only contains permitted characters
+    public, sep, local = version.partition('+')
+    local_sanetized = re.sub(r'[^a-zA-Z0-9.]', '.', local)
+    return public + sep + local_sanetized


### PR DESCRIPTION
When putting a branch name after the + it may often contain characters which
outside of what's allowed by PEP 440. Replace them by '.' as needed

Recent pip versions are more stringent.